### PR TITLE
As/correction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The bare minimum code that one will have to write to build a working sync adapte
 
 # Know and remember when using SyncAdapters in your apps
 - You will have to compulsorily use the `AccountManager` framework of Android.
-- You will have to compulsorily declare `StubProvider` in your app unless you are using any of the Content providers provided by Android framework or any other Content provider accessible to your app. You
+- You will have to compulsorily declare `StubProvider` in your app if you are not using any of the Content providers provided by Android framework or any other Content provider accessible to your app. You
 may choose not to use it though and use your own database for content storage.
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The bare minimum code that one will have to write to build a working sync adapte
 
 # Know and remember when using SyncAdapters in your apps
 - You will have to compulsorily use the `AccountManager` framework of Android.
-- You will have to compulsorily declare `StubProvider` in your app. You
+- You will have to compulsorily declare `StubProvider` in your app unless you are using any of the Content providers provided by Android framework or any other Content provider accessible to your app. You
 may choose not to use it though and use your own database for content storage.
 
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Note: In my experience, using `strings.xml` or any other way to declare
 I know this sounds weird.
 ```
 
+# Donations!
+If this project has helped you understand issues, be productive by using this library in your app or just being nice to me, you can always donate me
+
+* **Using Bitcoins**: at this address `3QJEmgqXsT1CFLtURYWxzmww59DdKYVwNk`
+
+* **Using Paypal**: [Pay Jay](https://www.paypal.me/jaydeepw)
+
 # Inspiration
 - [UDI COHEN's outdated blog post.](http://blog.udinic.com/2013/07/24/write-your-own-android-sync-adapter) Yet thankful to it.
 - [Obsolete sync adapter github projects](https://github.com/search?utf8=%E2%9C%93&q=sync+adapter+language%3AJava&type=Repositories&ref=advsearch&l=Java&l=)


### PR DESCRIPTION
Minor correction in readme. You don't have to create stubProvider if you are using any CP which is linked to the Sync Adapter.